### PR TITLE
Use pull_request_target

### DIFF
--- a/.github/workflows/recce_ci.yml
+++ b/.github/workflows/recce_ci.yml
@@ -1,7 +1,7 @@
 name: Recce CI
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
     paths:


### PR DESCRIPTION
In order to make GitHub Secrets and Variables available in CI for external PRs.