### PR TITLE
Upload DuckDB in CI and configure Codespace

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/vscode/devcontainers/python:3.12
+
+COPY pyproject.toml .
+COPY poetry.lock .
+
+RUN pip install poetry && poetry install

--- a/.devcontainer/recce/devcontainer.json
+++ b/.devcontainer/recce/devcontainer.json
@@ -1,0 +1,15 @@
+{
+    "name": "Recce CodeSpace",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": "../../"
+    },
+    "features": {
+        "ghcr.io/devcontainers/features/github-cli:1": {}
+    },
+    "containerEnv": {
+        "RECCE_STATE_PASSWORD": "${{ secrets.RECCE_STATE_PASSWORD }}"
+    },
+    "forwardPorts": [8000],
+    "postStartCommand": "./.devcontainer/scripts/post_start.sh"
+}

--- a/.devcontainer/scripts/post_start.sh
+++ b/.devcontainer/scripts/post_start.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+# Install dbt dependencies
+poetry run dbt deps
+
+# Download duckdb file
+gh repo set-default DataRecce/jaffle_shop_duckdb
+branch=$(git branch --show-current)
+run_id=$(gh run list --workflow "Recce CI" --branch $branch --status success --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run download $run_id -n duckdb
+
+# Exec Recce
+poetry run recce server --cloud --review

--- a/.github/workflows/recce_ci.yml
+++ b/.github/workflows/recce_ci.yml
@@ -48,6 +48,13 @@ jobs:
         run: |
           poetry run recce run --cloud
 
+      - name: Upload DuckDB
+        uses: actions/upload-artifact@v4
+        id: recce-artifact-uploader
+        with:
+          name: duckdb
+          path: us_campaign_finance.duckdb
+
       - name: Prepare Recce Summary
         id: recce-summary
         env:


### PR DESCRIPTION
- Configure Codespaces for Recce Cloud
- In order to avoid rerun dbt while launching Recce Instance, we store DuckDB in CI artifact.